### PR TITLE
Add dynamic project detail page

### DIFF
--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -1,0 +1,13 @@
+import Template from "@/components/Projects/template";
+import { projectDetails } from "@/components/Projects/data";
+import { notFound } from "next/navigation";
+
+export default function ProjectDetail({ params }: { params: { slug: string } }) {
+    const project = projectDetails.find((p) => p.slug === params.slug);
+
+    if(!project) return notFound()
+
+    return (
+        <Template {...project} />
+    );
+}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -8,8 +8,11 @@ export default function ProjectsPage() {
         <h1 className="text-4xl md:text-6xl font-bold text-center text-accent drop-shadow-lg mb-2 animate-fade-in">
           My Projects
         </h1>
-        <p className="text-lg md:text-2xl text-center text-text-muted mb-4 animate-fade-in">
+        <p className="text-lg md:text-2xl text-center text-text-muted animate-fade-in">
           Explore some of my favorite work, built with modern tech and a passion for solving real problems.
+        </p>
+        <p className="text-sm text-text-muted/80 text-center">
+          Tip: Click on a project to know more
         </p>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
           {Projects.map((project, idx) => (
@@ -22,6 +25,7 @@ export default function ProjectsPage() {
                 imageUrlLight={project.imageUrlLight}
                 name={project.name}
                 intro={project.intro}
+                slug={project.slug}
               />
             </div>
           ))}

--- a/src/components/Projects/data.tsx
+++ b/src/components/Projects/data.tsx
@@ -1,0 +1,188 @@
+import React from "react";
+import { ProjectDetailsProps } from "./template";
+
+export const projectDetails: ProjectDetailsProps[] = [
+  {
+    title: "Portly",
+    description: (
+      <div className="space-y-2">
+        <p>
+          AI-powered portfolio generator that parses resumes into responsive
+          websites.
+        </p>
+        <ul className="list-disc list-inside space-y-1">
+          <li>Built interactive dashboards using Next.js + Tailwind CSS.</li>
+          <li>Integrated MetaAI API for automated portfolio generation.</li>
+          <li>
+            Focused on clean UI/UX and fast deployment with Appwrite backend.
+          </li>
+        </ul>
+        <div className="flex gap-4">
+          <a
+            href="https://github.com/Aryan9inja/AppwriteHackathonProject"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent hover:underline"
+          >
+            GitHub
+          </a>
+          <a
+            href="https://portly.appwrite.network"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent hover:underline"
+          >
+            Live Demo
+          </a>
+        </div>
+      </div>
+    ),
+    imageDark: "/projects/portly.png",
+    imageLight: "/projects/portly_light.png",
+    technologies: ["React.js", "Appwrite", "Tailwind CSS", "MetaAI API"],
+    slug: "portly",
+  },
+  {
+    title: "Synote",
+    description: (
+      <div className="space-y-2">
+        <p>Full-stack SaaS app for note-taking and AI-powered summaries.</p>
+        <ul className="list-disc list-inside space-y-1">
+          <li>Developed JWT-secured REST APIs with Node.js + MongoDB.</li>
+          <li>
+            Integrated Mistral AI API to reduce note size by ~40% via summaries.
+          </li>
+          <li>
+            Deployed frontend (Vercel) and backend (Render) with CI/CD
+            pipelines.
+          </li>
+        </ul>
+        <div className="flex gap-4">
+          <a
+            href="https://github.com/Aryan9inja/Synote-Frontend"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent hover:underline"
+          >
+            Frontend
+          </a>
+          <a
+            href="https://github.com/Aryan9inja/Synote-Backend"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent hover:underline"
+          >
+            Backend
+          </a>
+          <a
+            href="https://synote-frontend.vercel.app/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent hover:underline"
+          >
+            Live
+          </a>
+        </div>
+      </div>
+    ),
+    imageDark: "/projects/synote.png",
+    imageLight: "/projects/synote_light.png",
+    technologies: ["React.js", "Node.js", "MongoDB", "Mistral AI API"],
+    slug: "synote",
+  },
+  {
+    title: "Shutr (Social Media App)",
+    description: (
+      <div className="space-y-2">
+        <p>Instagram-like social media app with real-time features.</p>
+        <ul className="list-disc list-inside space-y-1">
+          <li>
+            Built real-time chat using WebSockets supporting 50+ concurrent
+            users.
+          </li>
+          <li>
+            Implemented secure media uploads and scalable backend with NestJS
+            services.
+          </li>
+          <li>Designed responsive, mobile-first UI using Tailwind CSS.</li>
+        </ul>
+        <div className="flex gap-4">
+          <a
+            href="https://github.com/Aryan9inja/Shutr_Social-media-app"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent hover:underline"
+          >
+            Frontend
+          </a>
+          <a
+            href="https://github.com/Aryan9inja/ChatServiceNestJs"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent hover:underline"
+          >
+            Chat Service
+          </a>
+          <a
+            href="http://shutr-social-media-app.vercel.app"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent hover:underline"
+          >
+            Live
+          </a>
+        </div>
+      </div>
+    ),
+    imageDark: "/projects/shutr.png",
+    imageLight: "/projects/shutr_light.png",
+    technologies: [
+      "React.js",
+      "NestJS",
+      "WebSockets",
+      "Appwrite",
+      "Tailwind CSS",
+    ],
+    slug: "shutr",
+  },
+  {
+    title: "Flowceipt",
+    description: (
+      <div className="space-y-2">
+        <p>Receipt management and payment automation system.</p>
+        <ul className="list-disc list-inside space-y-1">
+          <li>
+            Automated receipt processing using OCR + GPT API achieving 90%+
+            accuracy.
+          </li>
+          <li>Integrated Stripe Subscriptions for secure payment flows.</li>
+          <li>
+            Optimized Supabase queries for 30% faster data retrieval and smooth
+            UX.
+          </li>
+        </ul>
+        <div className="flex gap-4">
+          <a
+            href="https://github.com/Aryan9inja/Flowceipt"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent hover:underline"
+          >
+            Repo Link
+          </a>
+        </div>
+      </div>
+    ),
+    imageDark: "/projects/flowceipt.png",
+    imageLight: "/projects/flowceipt_light.png",
+    technologies: [
+      "Node.js",
+      "Express.js",
+      "React",
+      "Stripe",
+      "OCR",
+      "GPT API",
+    ],
+    slug: "flowceipt",
+  },
+];

--- a/src/components/Projects/projectData.tsx
+++ b/src/components/Projects/projectData.tsx
@@ -6,23 +6,27 @@ export const Projects: ProjectProps[] = [
     imageUrlLight: "/projects/portly_light.png",
     name: "Portly",
     intro: "AI Powered Resume to Portfolio Website Builder",
+    slug: "/portly",
   },
   {
     imageUrldark: "/projects/flowceipt.png",
     imageUrlLight: "/projects/flowceipt_light.png",
     name: "Flowceipt",
     intro: "AI-Powered Receipt & Expense Manager",
+    slug: "/flowceipt",
   },
   {
     imageUrldark: "/projects/synote.png",
     imageUrlLight: "/projects/synote_light.png",
     name: "Synote",
     intro: "Smart Note/Tasks management app",
+    slug: "/synote",
   },
   {
     imageUrldark: "/projects/shutr.png",
     imageUrlLight: "/projects/shutr_light.png",
     name: "Shutr",
     intro: "Instagram-inspired Social Media Platform",
+    slug: "/shutr",
   },
 ];

--- a/src/components/Projects/projectTemplate.tsx
+++ b/src/components/Projects/projectTemplate.tsx
@@ -3,12 +3,14 @@
 import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 
 export interface ProjectProps {
   imageUrldark: string;
   imageUrlLight: string;
   name: string;
   intro: string;
+  slug: string;
 }
 
 export default function ProjectTemplate({
@@ -16,24 +18,40 @@ export default function ProjectTemplate({
   imageUrlLight,
   name,
   intro,
+  slug,
 }: ProjectProps) {
   const { resolvedTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
+  const [imageLoaded, setImageLoaded] = useState(false);
+
+  const router = useRouter();
+
   useEffect(() => {
     setMounted(true);
   }, []);
   return (
-    <section className="rounded-3xl shadow-xl p-6 md:p-8 flex flex-col items-center gap-8 border border-border transition-all duration-300 hover:shadow-2xl hover:border-accent/60 cursor-pointer">
+    <section
+      onClick={() => router.push(`/projects/${slug}`)}
+      className="rounded-3xl shadow-xl p-6 md:p-8 flex flex-col items-center gap-8 border border-border transition-all duration-300 hover:shadow-2xl hover:border-accent/60 cursor-pointer"
+    >
       <div className="flex items-center justify-center mb-4 w-full relative aspect-[16/9]">
         {mounted ? (
-          <Image
-            src={resolvedTheme == "dark" ? imageUrldark : imageUrlLight}
-            alt="Project Screenshot"
-            fill
-            sizes="(max-width: 768px) 100vw, 640px"
-            className="object-cover shadow-lg border border-dashed border-accent/40 hover:border-accent transition duration-300 rounded-lg"
-            priority
-          />
+          <>
+            {!imageLoaded && (
+              <div className="w-full h-full bg-gray-200 dark:bg-gray-800 animate-pulse rounded-lg absolute inset-0 z-10 flex items-center justify-center">
+                <span className="loader border-4 border-accent border-t-transparent rounded-full w-10 h-10 animate-spin" />
+              </div>
+            )}
+            <Image
+              src={resolvedTheme == "dark" ? imageUrldark : imageUrlLight}
+              alt="Project Screenshot"
+              fill
+              sizes="(max-width: 768px) 100vw, 640px"
+              className="object-cover shadow-lg border border-dashed border-accent/40 hover:border-accent transition duration-300 rounded-lg"
+              priority
+              onLoad={() => setImageLoaded(true)}
+            />
+          </>
         ) : (
           <div className="w-full h-full bg-gray-200 dark:bg-gray-800 animate-pulse rounded-lg" />
         )}

--- a/src/components/Projects/template.tsx
+++ b/src/components/Projects/template.tsx
@@ -1,0 +1,87 @@
+"use client"
+
+import Image from "next/image";
+import React, { useState, useEffect } from "react";
+import { useTheme } from "next-themes";
+
+export interface ProjectDetailsProps {
+  title: string;
+  description: React.ReactNode;
+  imageDark: string;
+  imageLight: string;
+  technologies?: string[];
+  link?: string;
+  slug:string;
+}
+
+export default function Template(props: ProjectDetailsProps) {
+  const { title, description, imageDark, imageLight, technologies, link } =
+    props;
+  const { resolvedTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  const [imageLoaded, setImageLoaded] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const image = mounted ? (resolvedTheme === "dark" ? imageDark : imageLight) : undefined;
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center">
+      <div className="w-full max-w-4xl px-4 md:px-8 py-8 flex flex-col gap-10">
+        <section className="rounded-3xl shadow-xl p-6 md:p-8 flex flex-col items-center gap-8 cursor-pointer">
+          {image && (
+            <div className="flex items-center justify-center mb-4 w-full relative aspect-[16/9]">
+              {!imageLoaded && (
+                <div className="w-full h-full bg-gray-200 dark:bg-gray-800 animate-pulse rounded-lg absolute inset-0 z-10 flex items-center justify-center">
+                  <span className="loader border-4 border-accent border-t-transparent rounded-full w-10 h-10 animate-spin" />
+                </div>
+              )}
+              <Image
+                src={image}
+                alt={title}
+                width={1920}
+                height={1080}
+                className="object-cover shadow-lg border border-dashed border-accent/40 hover:border-accent transition duration-300 rounded-lg"
+                priority
+                onLoad={() => setImageLoaded(true)}
+              />
+            </div>
+          )}
+          <div className="flex flex-col gap-3 w-full">
+            <h2 className="text-2xl md:text-4xl font-bold mb-1 text-accent font-playfair animate-fade-in">
+              {title}
+            </h2>
+            <div className="text-base md:text-lg text-text mb-2 animate-fade-in">
+              {description}
+            </div>
+            {technologies && (
+              <ul className="flex flex-wrap gap-2 mt-2">
+                {technologies.map((tech, idx) => (
+                  <li
+                    key={idx}
+                    className="px-3 py-1 rounded-full bg-accent/10 text-accent text-xs md:text-sm font-medium border border-accent/30"
+                  >
+                    {tech}
+                  </li>
+                ))}
+              </ul>
+            )}
+            {link && (
+              <a
+                href={link}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-block mt-4 px-5 py-2 rounded-lg bg-accent text-text-inverse font-semibold shadow hover:bg-accent-hover transition-colors focus:outline-none focus:ring-2 focus:ring-accent"
+                aria-label={`View ${title} project`}
+              >
+                View Project
+              </a>
+            )}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
This pull request adds project detail pages to the portfolio site, allowing users to click on a project and view its full description, tech stack, and related links. It introduces new data structures for detailed project information, implements navigation and loading states for project images, and updates the project listing to support this feature.

**Project detail page implementation:**

* Added a new dynamic route (`src/app/projects/[slug]/page.tsx`) that renders a detailed view for each project using the new `Template` component and project details data. ([src/app/projects/[slug]/page.tsxR1-R13](diffhunk://#diff-1d2a210291c84a2d68494da2260754887ddacc859763a29c124230fa22f487bbR1-R13), [src/components/Projects/template.tsxR1-R87](diffhunk://#diff-75d94810869bb3c2833c2313ef6366afa03cddd087204c98fa20185712e95e6dR1-R87))
* Created `projectDetails` data in `src/components/Projects/data.tsx` to store rich information about each project, including title, description, images, technologies, and links.
* Implemented the `Template` component to display project details, technology tags, and external links, with theme-aware image loading and skeleton loading states.

**Project list enhancements and navigation:**

* Updated `ProjectTemplate` in `src/components/Projects/projectTemplate.tsx` to accept a `slug` prop and navigate to the corresponding project detail page on click, with improved image loading UX.
* Modified project list data (`src/components/Projects/projectData.tsx`) and project card rendering to include and pass the new `slug` property for routing. [[1]](diffhunk://#diff-30e4c3cd1bf5f591e9032d6e17f6b608fb0c272cd8d5493d3c30b904c83fdebcR9-R30) [[2]](diffhunk://#diff-77154bf8a7b0126e79f2818a349df89aaaffda07cf88710602c844958985b12fR28)
* Added a tip to the projects page encouraging users to click on projects for more information.